### PR TITLE
Set purple background for app layout

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,5 +1,6 @@
 body {
   font-family: Gordita, Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  background-color: #4b2d7f;
 }
 
 a {


### PR DESCRIPTION
## Summary
- set the global page background color to a deep purple shade to align with the requested styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8e7a8ded4832e8d840fbb8f25451b