### PR TITLE
feat: apply purple background styling

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,5 +1,7 @@
 body {
   font-family: Gordita, Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  background-color: #6b21a8;
+  color: #f8fafc;
 }
 
 a {
@@ -13,7 +15,7 @@ main {
 }
 
 h1 {
-  color: #335d92;
+  color: #ede9fe;
   text-transform: uppercase;
   font-size: 4rem;
   font-weight: 100;


### PR DESCRIPTION
## Summary
- set the global page background to a deep purple and update the default text color for readability
- lighten the heading color so it contrasts cleanly with the new background

## Testing
- yarn dev

------
https://chatgpt.com/codex/tasks/task_e_68d8e7a8ded4832e8d840fbb8f25451b