### PR TITLE
Simplify NBA scoreboard widget

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -39,3 +39,25 @@ p {
     max-width: none;
   }
 }
+
+.nba-games {
+  margin: 2.5rem auto;
+  max-width: 32rem;
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.5);
+}
+
+.nba-games h2 {
+  margin: 0 0 1rem;
+  text-align: center;
+}
+
+.nba-games p {
+  margin: 0;
+  text-align: center;
+}
+
+.nba-games .error {
+  color: #fecdd3;
+}

--- a/src/components/NbaGameLogs.tsx
+++ b/src/components/NbaGameLogs.tsx
@@ -1,0 +1,42 @@
+import { Show, createResource } from "solid-js";
+
+type ScoreboardResponse = {
+  events?: { id: string }[];
+};
+
+async function fetchTodayScoreboard() {
+  const response = await fetch(
+    "https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard"
+  );
+
+  if (!response.ok) {
+    throw new Error("Unable to fetch the latest NBA scoreboard.");
+  }
+
+  const data = (await response.json()) as ScoreboardResponse;
+  return data;
+}
+
+export default function NbaGameLogs() {
+  const [scoreboard] = createResource(fetchTodayScoreboard);
+
+  const gameCount = () => scoreboard()?.events?.length ?? 0;
+
+  return (
+    <section class="nba-games">
+      <h2>Today's NBA Games</h2>
+      <Show when={scoreboard.error}>
+        {(error) => <p class="error">{error.message}</p>}
+      </Show>
+      <Show when={!scoreboard.error}>
+        <Show when={!scoreboard.loading} fallback={<p>Loading…</p>}>
+          <p>
+            {gameCount() === 0
+              ? "No NBA games are scheduled today."
+              : `There are ${gameCount()} NBA games scheduled today.`}
+          </p>
+        </Show>
+      </Show>
+    </section>
+  );
+}

--- a/src/routes/index.mdx
+++ b/src/routes/index.mdx
@@ -1,7 +1,12 @@
 import Counter from "~/components/Counter";
+import NbaGameLogs from "~/components/NbaGameLogs";
 
 # Hello World!
 
 <Counter />
 
 Visit [https://solidjs.com](https://solidjs.com) to learn how to build Solid apps.
+
+<NbaGameLogs />
+
+> Data provided by ESPN's free [NBA scoreboard API](https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard).


### PR DESCRIPTION
## Summary
- replace the NBA scoreboard component with a simple fetch that reports how many games are scheduled today
- clean up the accompanying styles to match the simplified presentation

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68da23fd06b4832ebcd220eea82726f7