### PR TITLE
Refactor Curry dashboard into MDX sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
 		"@solidjs/router": "^0.15.0",
 		"@solidjs/start": "^1.1.0",
 		"@vinxi/plugin-mdx": "^3.7.1",
+		"chart.js": "^4.5.0",
+		"solid-chartjs": "^1.3.11",
 		"solid-js": "^1.9.5",
 		"solid-mdx": "^0.0.7",
 		"vinxi": "^0.5.7"

--- a/src/app.css
+++ b/src/app.css
@@ -1,41 +1,364 @@
+:root {
+  color-scheme: dark;
+  --surface: rgba(15, 23, 42, 0.82);
+  --surface-soft: rgba(30, 41, 59, 0.72);
+  --surface-strong: rgba(15, 23, 42, 0.92);
+  --accent: #f97316;
+  --accent-soft: rgba(249, 115, 22, 0.18);
+  --text-primary: #f8fafc;
+  --text-secondary: #cbd5f5;
+  --border: rgba(148, 163, 184, 0.25);
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
-  font-family: Gordita, Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-  background-color: lightpink;
-  color: #f8fafc;
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Inter", "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 20% 20%, #0f172a 0%, #020617 65%, #000 100%);
+  color: var(--text-primary);
 }
 
 a {
-  margin-right: 1rem;
+  color: inherit;
+  text-decoration: none;
 }
 
-main {
-  text-align: center;
-  padding: 1em;
+a:hover {
+  text-decoration: underline;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem clamp(1.25rem, 3vw, 3.5rem) 2.5rem;
+}
+
+.app-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  background: var(--surface);
+  backdrop-filter: blur(18px);
+  padding: 1.5rem 2rem;
+  border-radius: 1.25rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 25px 55px rgba(2, 8, 23, 0.55);
+}
+
+.branding {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.logo {
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.tagline {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+.main-nav {
+  display: inline-flex;
+  gap: 1rem;
+  padding: 0.35rem;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 999px;
+  border: 1px solid var(--border);
+}
+
+.main-nav a {
+  padding: 0.45rem 1.15rem;
+  border-radius: 999px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  transition: all 0.2s ease;
+}
+
+.main-nav a:hover {
+  color: var(--text-primary);
+}
+
+.main-nav a.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  box-shadow: inset 0 0 0 1px rgba(249, 115, 22, 0.6);
+}
+
+.app-main {
+  flex: 1;
+  width: min(1200px, 100%);
   margin: 0 auto;
 }
 
-h1 {
-  color: #ede9fe;
+.app-footer {
+  margin-top: auto;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.curry-dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.dashboard-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+  background: var(--surface-strong);
+  border-radius: 1.5rem;
+  border: 1px solid var(--border);
+  padding: clamp(1.8rem, 3vw, 3.5rem);
+  position: relative;
+  overflow: hidden;
+}
+
+.dashboard-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 80% 20%, rgba(249, 115, 22, 0.25), transparent 55%);
+  opacity: 0.75;
+}
+
+.dashboard-hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.eyebrow {
   text-transform: uppercase;
-  font-size: 4rem;
-  font-weight: 100;
-  line-height: 1.1;
-  margin: 4rem auto;
-  max-width: 14rem;
+  letter-spacing: 0.3em;
+  font-size: 0.75rem;
+  color: var(--accent);
+  margin-bottom: 0.5rem;
 }
 
-p {
-  max-width: 14rem;
-  margin: 2rem auto;
-  line-height: 1.35;
+.dashboard-hero h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 4vw, 3.1rem);
+  line-height: 1.2;
 }
 
-@media (min-width: 480px) {
-  h1 {
-    max-width: none;
+.lead {
+  margin-top: 1rem;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+}
+
+.hero-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.8rem;
+}
+
+.cta {
+  padding: 0.65rem 1.3rem;
+  border-radius: 999px;
+  font-weight: 600;
+  background: var(--accent);
+  color: #0b1120;
+  box-shadow: 0 15px 35px rgba(249, 115, 22, 0.4);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cta:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 45px rgba(249, 115, 22, 0.45);
+  text-decoration: none;
+}
+
+.cta.secondary {
+  background: transparent;
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  box-shadow: none;
+}
+
+.hero-highlight {
+  background: rgba(15, 23, 42, 0.72);
+  border-radius: 1.25rem;
+  border: 1px solid var(--border);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.hero-highlight h2 {
+  margin: 0;
+  font-size: 1.75rem;
+  color: var(--accent);
+}
+
+.result-tag {
+  display: inline-flex;
+  align-self: flex-start;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(16, 185, 129, 0.15);
+  color: #5eead4;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.hero-highlight .note {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.stat-card {
+  background: var(--surface);
+  border-radius: 1.25rem;
+  border: 1px solid var(--border);
+  padding: 1.5rem;
+  box-shadow: 0 20px 50px rgba(2, 8, 23, 0.4);
+}
+
+.stat-card h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.stat-value {
+  margin: 0.65rem 0 0.35rem;
+  font-size: 1.8rem;
+  font-weight: 700;
+}
+
+.stat-subtitle {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.chart-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.chart-card {
+  background: var(--surface-soft);
+  border-radius: 1.25rem;
+  border: 1px solid var(--border);
+  padding: 1rem 1.25rem;
+  box-shadow: 0 18px 45px rgba(2, 8, 23, 0.35);
+}
+
+.table-card {
+  background: var(--surface-strong);
+  border-radius: 1.5rem;
+  border: 1px solid var(--border);
+  padding: 1.8rem;
+  box-shadow: 0 28px 60px rgba(2, 8, 23, 0.45);
+}
+
+.table-card header h2 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.table-card header p {
+  margin-top: 0.65rem;
+  margin-bottom: 1.5rem;
+  color: var(--text-secondary);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  border-radius: 1rem;
+}
+
+.game-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.game-table thead {
+  background: rgba(15, 23, 42, 0.75);
+}
+
+.game-table th,
+.game-table td {
+  padding: 0.9rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.game-table tbody tr:hover {
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.date-cell {
+  font-weight: 600;
+}
+
+.opponent {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 600;
+}
+
+.competition {
+  display: block;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
+@media (max-width: 720px) {
+  .app-shell {
+    padding: 1.25rem;
   }
 
-  p {
-    max-width: none;
+  .app-header {
+    padding: 1.2rem 1.4rem;
+  }
+
+  .main-nav {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .main-nav a {
+    flex: 1;
+    text-align: center;
+  }
+
+  .chart-card {
+    padding: 0.85rem 0.9rem;
   }
 }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,4 +1,4 @@
-import { Router } from "@solidjs/router";
+import { A, Router } from "@solidjs/router";
 import { FileRoutes } from "@solidjs/start/router";
 import { Suspense } from "solid-js";
 import "./app.css";
@@ -7,11 +7,30 @@ export default function App() {
   return (
     <Router
       root={props => (
-        <main>
-          <a href="/">Index</a>
-          <a href="/about">About</a>
-          <Suspense>{props.children}</Suspense>
-        </main>
+        <div class="app-shell">
+          <header class="app-header">
+            <div class="branding">
+              <span class="logo">NBA Legends Lab</span>
+              <p class="tagline">Data-rich storytelling for basketball&apos;s biggest nights.</p>
+            </div>
+            <nav class="main-nav">
+              <A href="/" end activeClass="active">
+                Curry Showcase
+              </A>
+              <A href="/about" activeClass="active">
+                About
+              </A>
+            </nav>
+          </header>
+          <main class="app-main">
+            <Suspense>{props.children}</Suspense>
+          </main>
+          <footer class="app-footer">
+            <p>
+              Crafted for hoops obsessives. Data sourced from Basketball-Reference box scores.
+            </p>
+          </footer>
+        </div>
       )}
     >
       <FileRoutes />

--- a/src/components/CurryDashboard.tsx
+++ b/src/components/CurryDashboard.tsx
@@ -1,0 +1,358 @@
+import { Chart as ChartJS, Filler, Legend, Title, Tooltip } from "chart.js";
+import { Component, createMemo } from "solid-js";
+import { curryGameLogs } from "~/data/curryGameLogs";
+import CurryChartGrid from "~/components/curry/CurryChartGrid.mdx";
+import CurryGameLogTable from "~/components/curry/CurryGameLogTable.mdx";
+import CurryHero from "~/components/curry/CurryHero.mdx";
+import CurryStatGrid from "~/components/curry/CurryStatGrid.mdx";
+
+ChartJS.register(Filler, Legend, Title, Tooltip);
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+const locationBadge = (location: string) => {
+  switch (location) {
+    case "Home":
+      return "🏠";
+    case "Away":
+      return "✈️";
+    default:
+      return "🎯";
+  }
+};
+
+const CurryDashboard: Component = () => {
+  const gamesByDate = createMemo(() =>
+    [...curryGameLogs].sort(
+      (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+    )
+  );
+
+  const totals = createMemo(() =>
+    gamesByDate().reduce(
+      (acc, game) => {
+        acc.points += game.points;
+        acc.rebounds += game.rebounds;
+        acc.assists += game.assists;
+        acc.steals += game.steals;
+        acc.threes += game.threesMade;
+        acc.gameScore += game.gameScore;
+        return acc;
+      },
+      { points: 0, rebounds: 0, assists: 0, steals: 0, threes: 0, gameScore: 0 }
+    )
+  );
+
+  const averages = createMemo(() => {
+    const count = gamesByDate().length;
+    const summary = totals();
+    return {
+      points: summary.points / count,
+      rebounds: summary.rebounds / count,
+      assists: summary.assists / count,
+      steals: summary.steals / count,
+      threes: summary.threes / count,
+      gameScore: summary.gameScore / count,
+    };
+  });
+
+  const bestScoringNight = createMemo(() =>
+    gamesByDate().reduce((best, game) =>
+      game.points > best.points ? game : best
+    )
+  );
+
+  const bestGameScoreNight = createMemo(() =>
+    gamesByDate().reduce((best, game) =>
+      game.gameScore > best.gameScore ? game : best
+    )
+  );
+
+  const recordThreesNight = createMemo(() =>
+    gamesByDate().reduce((best, game) =>
+      game.threesMade > best.threesMade ? game : best
+    )
+  );
+
+  const labels = createMemo(() =>
+    gamesByDate().map(
+      game => `${dateFormatter.format(new Date(game.date))} vs ${game.opponent}`
+    )
+  );
+
+  const pointsTrend = createMemo(() => ({
+    labels: labels(),
+    datasets: [
+      {
+        label: "Points",
+        data: gamesByDate().map(game => game.points),
+        borderColor: "#f97316",
+        backgroundColor: "rgba(249, 115, 22, 0.25)",
+        tension: 0.35,
+        borderWidth: 3,
+        pointRadius: 6,
+        pointHoverRadius: 8,
+        fill: true,
+      },
+    ],
+  }));
+
+  const scoringDistribution = createMemo(() => ({
+    labels: labels(),
+    datasets: [
+      {
+        label: "Field Goals Made",
+        backgroundColor: "rgba(59, 130, 246, 0.75)",
+        data: gamesByDate().map(game => game.fieldGoalsMade),
+      },
+      {
+        label: "3PM",
+        backgroundColor: "rgba(234, 179, 8, 0.85)",
+        data: gamesByDate().map(game => game.threesMade),
+      },
+      {
+        label: "FTM",
+        backgroundColor: "rgba(16, 185, 129, 0.75)",
+        data: gamesByDate().map(game => game.freeThrowsMade),
+      },
+    ],
+  }));
+
+  const radarComparison = createMemo(() => {
+    const maxPoints = Math.max(...gamesByDate().map(game => game.points));
+    const maxRebounds = Math.max(...gamesByDate().map(game => game.rebounds));
+    const maxAssists = Math.max(...gamesByDate().map(game => game.assists));
+    const maxSteals = Math.max(...gamesByDate().map(game => game.steals));
+    const maxThrees = Math.max(...gamesByDate().map(game => game.threesMade));
+
+    const average = averages();
+
+    return {
+      labels: ["Points", "Rebounds", "Assists", "Steals", "3PM"],
+      datasets: [
+        {
+          label: "Average of elite nights",
+          data: [
+            average.points,
+            average.rebounds,
+            average.assists,
+            average.steals,
+            average.threes,
+          ],
+          backgroundColor: "rgba(147, 51, 234, 0.3)",
+          borderColor: "#9333ea",
+          borderWidth: 2,
+          pointBackgroundColor: "#9333ea",
+        },
+        {
+          label: "Peak single-game marks",
+          data: [maxPoints, maxRebounds, maxAssists, maxSteals, maxThrees],
+          backgroundColor: "rgba(234, 179, 8, 0.2)",
+          borderColor: "#eab308",
+          borderWidth: 2,
+          pointBackgroundColor: "#eab308",
+        },
+      ],
+    };
+  });
+
+  const efficiencyScatter = createMemo(() => ({
+    datasets: [
+      {
+        label: "Game Score vs. Points",
+        data: gamesByDate().map(game => ({
+          x: game.points,
+          y: game.gameScore,
+        })),
+        pointBackgroundColor: "rgba(14, 165, 233, 0.9)",
+        pointBorderColor: "#0ea5e9",
+        pointRadius: gamesByDate().map(game => 5 + game.threesMade * 0.2),
+        pointHoverRadius: gamesByDate().map(game => 7 + game.threesMade * 0.2),
+        showLine: false,
+      },
+    ],
+  }));
+
+  const pointsTrendOptions = {
+    responsive: true,
+    plugins: {
+      legend: { display: false },
+      title: {
+        display: true,
+        text: "Point eruptions over time",
+        color: "#f8fafc",
+        font: { size: 18, weight: "600" },
+        padding: { top: 10, bottom: 16 },
+      },
+      tooltip: {
+        callbacks: {
+          title(items: any[]) {
+            const item = items[0];
+            return labels()[item.dataIndex];
+          },
+        },
+      },
+    },
+    scales: {
+      x: {
+        ticks: {
+          color: "#cbd5f5",
+          maxRotation: 35,
+          minRotation: 35,
+        },
+        grid: { color: "rgba(148, 163, 184, 0.2)" },
+      },
+      y: {
+        ticks: { color: "#cbd5f5" },
+        grid: { color: "rgba(148, 163, 184, 0.2)" },
+      },
+    },
+  } as const;
+
+  const barOptions = {
+    responsive: true,
+    plugins: {
+      legend: {
+        position: "top" as const,
+        labels: { color: "#e2e8f0" },
+      },
+      title: {
+        display: true,
+        text: "Shot profile in signature games",
+        color: "#f8fafc",
+        font: { size: 18, weight: "600" },
+        padding: { bottom: 12 },
+      },
+    },
+    scales: {
+      x: {
+        ticks: {
+          color: "#cbd5f5",
+          maxRotation: 30,
+          minRotation: 30,
+        },
+        grid: { display: false },
+      },
+      y: {
+        ticks: { color: "#cbd5f5" },
+        grid: { color: "rgba(148, 163, 184, 0.2)" },
+      },
+    },
+  } as const;
+
+  const radarOptions = {
+    responsive: true,
+    plugins: {
+      legend: {
+        position: "top" as const,
+        labels: { color: "#e2e8f0" },
+      },
+      title: {
+        display: true,
+        text: "All-around output",
+        color: "#f8fafc",
+        font: { size: 18, weight: "600" },
+        padding: { bottom: 12 },
+      },
+    },
+    scales: {
+      r: {
+        angleLines: { color: "rgba(148, 163, 184, 0.25)" },
+        grid: { color: "rgba(148, 163, 184, 0.25)" },
+        pointLabels: { color: "#f8fafc" },
+        ticks: {
+          color: "#cbd5f5",
+          backdropColor: "transparent",
+        },
+      },
+    },
+  } as const;
+
+  const scatterOptions = {
+    responsive: true,
+    plugins: {
+      legend: {
+        position: "top" as const,
+        labels: { color: "#e2e8f0" },
+      },
+      title: {
+        display: true,
+        text: "Scoring volume vs. Game Score",
+        color: "#f8fafc",
+        font: { size: 18, weight: "600" },
+        padding: { bottom: 12 },
+      },
+      tooltip: {
+        callbacks: {
+          label(context: any) {
+            const game = gamesByDate()[context.dataIndex];
+            return `${game.points} pts, Game Score ${game.gameScore.toFixed(
+              1
+            )}`;
+          },
+          title(context: any[]) {
+            const game = gamesByDate()[context[0].dataIndex];
+            return `${dateFormatter.format(new Date(game.date))} vs ${game.opponent}`;
+          },
+        },
+      },
+    },
+    scales: {
+      x: {
+        title: {
+          display: true,
+          text: "Points",
+          color: "#e2e8f0",
+        },
+        ticks: { color: "#cbd5f5" },
+        grid: { color: "rgba(148, 163, 184, 0.2)" },
+      },
+      y: {
+        title: {
+          display: true,
+          text: "Game Score",
+          color: "#e2e8f0",
+        },
+        ticks: { color: "#cbd5f5" },
+        grid: { color: "rgba(148, 163, 184, 0.2)" },
+      },
+    },
+  } as const;
+
+  const formatDate = (value: string) => dateFormatter.format(new Date(value));
+
+  return (
+    <section class="curry-dashboard">
+      <CurryHero highlight={bestScoringNight()} formatDate={formatDate} />
+      <CurryStatGrid
+        totals={totals()}
+        averages={averages()}
+        count={gamesByDate().length}
+        bestGameScoreNight={bestGameScoreNight()}
+        recordThreesNight={recordThreesNight()}
+        formatDate={formatDate}
+      />
+      <CurryChartGrid
+        pointsTrendData={pointsTrend()}
+        scoringDistributionData={scoringDistribution()}
+        radarComparisonData={radarComparison()}
+        efficiencyScatterData={efficiencyScatter()}
+        pointsTrendOptions={pointsTrendOptions}
+        barOptions={barOptions}
+        radarOptions={radarOptions}
+        scatterOptions={scatterOptions}
+      />
+      <CurryGameLogTable
+        games={gamesByDate()}
+        formatDate={formatDate}
+        locationBadge={locationBadge}
+      />
+    </section>
+  );
+};
+
+export default CurryDashboard;

--- a/src/components/curry/CurryChartGrid.mdx
+++ b/src/components/curry/CurryChartGrid.mdx
@@ -1,0 +1,20 @@
+import { Bar, Line, Radar, Scatter } from "solid-chartjs";
+
+export default function CurryChartGrid(props) {
+  return (
+    <section class="chart-grid">
+      <figure class="chart-card">
+        <Line data={props.pointsTrendData} options={props.pointsTrendOptions} />
+      </figure>
+      <figure class="chart-card">
+        <Bar data={props.scoringDistributionData} options={props.barOptions} />
+      </figure>
+      <figure class="chart-card">
+        <Radar data={props.radarComparisonData} options={props.radarOptions} />
+      </figure>
+      <figure class="chart-card">
+        <Scatter data={props.efficiencyScatterData} options={props.scatterOptions} />
+      </figure>
+    </section>
+  );
+}

--- a/src/components/curry/CurryGameLogTable.mdx
+++ b/src/components/curry/CurryGameLogTable.mdx
@@ -1,0 +1,57 @@
+import { For } from "solid-js";
+
+export default function CurryGameLogTable(props) {
+  return (
+    <section class="table-card">
+      <header>
+        <h2>Game log details</h2>
+        <p>Every contest is hand-picked from official box scores and sorted chronologically.</p>
+      </header>
+      <div class="table-wrapper">
+        <table class="game-table">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Opponent</th>
+              <th>Pts</th>
+              <th>Reb</th>
+              <th>Ast</th>
+              <th>Stl</th>
+              <th>3PM</th>
+              <th>FGM</th>
+              <th>FTM</th>
+              <th>Game Score</th>
+              <th>Result</th>
+            </tr>
+          </thead>
+          <tbody>
+            <For each={props.games}>
+              {game => (
+                <tr>
+                  <td>
+                    <span class="date-cell">{props.formatDate(game.date)}</span>
+                  </td>
+                  <td>
+                    <span class="opponent">
+                      {props.locationBadge(game.location)} {game.opponent}
+                    </span>
+                    <span class="competition">{game.competition}</span>
+                  </td>
+                  <td>{game.points}</td>
+                  <td>{game.rebounds}</td>
+                  <td>{game.assists}</td>
+                  <td>{game.steals}</td>
+                  <td>{game.threesMade}</td>
+                  <td>{game.fieldGoalsMade}</td>
+                  <td>{game.freeThrowsMade}</td>
+                  <td>{game.gameScore.toFixed(1)}</td>
+                  <td>{game.result}</td>
+                </tr>
+              )}
+            </For>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/components/curry/CurryHero.mdx
+++ b/src/components/curry/CurryHero.mdx
@@ -1,0 +1,43 @@
+import { A } from "@solidjs/router";
+
+export default function CurryHero(props) {
+  return (
+    <header class="dashboard-hero">
+      <div>
+        <p class="eyebrow">Steph Showcase</p>
+        <h1>Stephen Curry&apos;s most volcanic box scores</h1>
+        <p class="lead">
+          A curated look at ten of the greatest single-game explosions from the greatest shooter ever.
+          Track how his volume, efficiency, and all-around control of the game shift from the regular
+          season to the playoffs and the NBA Finals.
+        </p>
+        <div class="hero-links">
+          <A
+            class="cta"
+            href="https://www.basketball-reference.com/players/c/curryst01/gamelog/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Full game logs
+          </A>
+          <A
+            class="cta secondary"
+            href="https://www.nba.com/player/201939/stephen-curry"
+            target="_blank"
+            rel="noreferrer"
+          >
+            NBA.com profile
+          </A>
+        </div>
+      </div>
+      <aside class="hero-highlight">
+        <h2>{props.highlight.points}-point masterpiece</h2>
+        <p>
+          {props.formatDate(props.highlight.date)} vs {props.highlight.opponent}
+        </p>
+        <p class="result-tag">{props.highlight.result}</p>
+        <p class="note">{props.highlight.note}</p>
+      </aside>
+    </header>
+  );
+}

--- a/src/components/curry/CurryStatGrid.mdx
+++ b/src/components/curry/CurryStatGrid.mdx
@@ -1,0 +1,30 @@
+export default function CurryStatGrid(props) {
+  return (
+    <section class="stat-grid">
+      <article class="stat-card">
+        <h3>Total points</h3>
+        <p class="stat-value">{props.totals.points}</p>
+        <p class="stat-subtitle">Across {props.count} legendary nights</p>
+      </article>
+      <article class="stat-card">
+        <h3>Average slash</h3>
+        <p class="stat-value">
+          {props.averages.points.toFixed(1)} pts · {props.averages.rebounds.toFixed(1)} reb · {props.averages.assists.toFixed(1)} ast
+        </p>
+        <p class="stat-subtitle">Game Score {props.averages.gameScore.toFixed(1)} per game</p>
+      </article>
+      <article class="stat-card">
+        <h3>Peak Game Score</h3>
+        <p class="stat-value">{props.bestGameScoreNight.gameScore.toFixed(1)}</p>
+        <p class="stat-subtitle">
+          {props.formatDate(props.bestGameScoreNight.date)} ({props.bestGameScoreNight.result})
+        </p>
+      </article>
+      <article class="stat-card">
+        <h3>Most threes</h3>
+        <p class="stat-value">{props.recordThreesNight.threesMade}</p>
+        <p class="stat-subtitle">{props.formatDate(props.recordThreesNight.date)}</p>
+      </article>
+    </section>
+  );
+}

--- a/src/data/curryGameLogs.ts
+++ b/src/data/curryGameLogs.ts
@@ -1,0 +1,179 @@
+export type CurryGameLog = {
+  date: string;
+  opponent: string;
+  location: "Home" | "Away" | "Neutral";
+  competition: "Regular Season" | "Playoffs" | "NBA Finals";
+  points: number;
+  rebounds: number;
+  assists: number;
+  steals: number;
+  threesMade: number;
+  fieldGoalsMade: number;
+  freeThrowsMade: number;
+  result: string;
+  gameScore: number;
+  note: string;
+};
+
+export const curryGameLogs: CurryGameLog[] = [
+  {
+    date: "2015-10-31",
+    opponent: "New Orleans Pelicans",
+    location: "Away",
+    competition: "Regular Season",
+    points: 53,
+    rebounds: 4,
+    assists: 9,
+    steals: 4,
+    threesMade: 8,
+    fieldGoalsMade: 17,
+    freeThrowsMade: 11,
+    result: "W 134-120",
+    gameScore: 49.2,
+    note: "35 first-half points to open the reigning MVP campaign with a statement road win."
+  },
+  {
+    date: "2013-02-27",
+    opponent: "New York Knicks",
+    location: "Away",
+    competition: "Regular Season",
+    points: 54,
+    rebounds: 6,
+    assists: 7,
+    steals: 3,
+    threesMade: 11,
+    fieldGoalsMade: 18,
+    freeThrowsMade: 7,
+    result: "L 109-105",
+    gameScore: 46.1,
+    note: "A national coming-out party at Madison Square Garden despite the narrow loss."
+  },
+  {
+    date: "2016-02-03",
+    opponent: "Washington Wizards",
+    location: "Away",
+    competition: "Regular Season",
+    points: 51,
+    rebounds: 7,
+    assists: 2,
+    steals: 3,
+    threesMade: 11,
+    fieldGoalsMade: 19,
+    freeThrowsMade: 2,
+    result: "W 134-121",
+    gameScore: 37.3,
+    note: "11 triples and a 25-point first quarter stunned the DC crowd."
+  },
+  {
+    date: "2016-02-27",
+    opponent: "Oklahoma City Thunder",
+    location: "Away",
+    competition: "Regular Season",
+    points: 46,
+    rebounds: 3,
+    assists: 6,
+    steals: 2,
+    threesMade: 12,
+    fieldGoalsMade: 14,
+    freeThrowsMade: 6,
+    result: "W 121-118 (OT)",
+    gameScore: 37.7,
+    note: "The 38-foot OT winner capped a record-tying night from deep."
+  },
+  {
+    date: "2016-11-07",
+    opponent: "New Orleans Pelicans",
+    location: "Home",
+    competition: "Regular Season",
+    points: 46,
+    rebounds: 5,
+    assists: 5,
+    steals: 2,
+    threesMade: 13,
+    fieldGoalsMade: 16,
+    freeThrowsMade: 1,
+    result: "W 116-106",
+    gameScore: 37.2,
+    note: "An NBA-record 13 three-pointers one game after his streak ended."
+  },
+  {
+    date: "2019-04-13",
+    opponent: "Los Angeles Clippers",
+    location: "Home",
+    competition: "Playoffs",
+    points: 38,
+    rebounds: 15,
+    assists: 7,
+    steals: 0,
+    threesMade: 8,
+    fieldGoalsMade: 11,
+    freeThrowsMade: 8,
+    result: "W 121-104",
+    gameScore: 36.5,
+    note: "Playoff opener dominance with a playoff career-high on the glass."
+  },
+  {
+    date: "2021-01-03",
+    opponent: "Portland Trail Blazers",
+    location: "Home",
+    competition: "Regular Season",
+    points: 62,
+    rebounds: 5,
+    assists: 4,
+    steals: 0,
+    threesMade: 8,
+    fieldGoalsMade: 18,
+    freeThrowsMade: 18,
+    result: "W 137-122",
+    gameScore: 46.8,
+    note: "Career-high 62 points silenced early-season doubters."
+  },
+  {
+    date: "2021-02-06",
+    opponent: "Dallas Mavericks",
+    location: "Away",
+    competition: "Regular Season",
+    points: 57,
+    rebounds: 2,
+    assists: 5,
+    steals: 1,
+    threesMade: 11,
+    fieldGoalsMade: 19,
+    freeThrowsMade: 8,
+    result: "L 134-132",
+    gameScore: 43.8,
+    note: "Duel with Luka Dončić produced one of the most efficient 50+ games ever."
+  },
+  {
+    date: "2021-11-08",
+    opponent: "Atlanta Hawks",
+    location: "Home",
+    competition: "Regular Season",
+    points: 50,
+    rebounds: 7,
+    assists: 10,
+    steals: 4,
+    threesMade: 9,
+    fieldGoalsMade: 14,
+    freeThrowsMade: 13,
+    result: "W 127-113",
+    gameScore: 48.6,
+    note: "50-point triple-double flirt with a +31 in 35 minutes."
+  },
+  {
+    date: "2022-06-10",
+    opponent: "Boston Celtics",
+    location: "Away",
+    competition: "NBA Finals",
+    points: 43,
+    rebounds: 10,
+    assists: 4,
+    steals: 0,
+    threesMade: 7,
+    fieldGoalsMade: 14,
+    freeThrowsMade: 8,
+    result: "W 107-97",
+    gameScore: 30.4,
+    note: "Iconic Finals Game 4 masterpiece to tie the series 2-2."
+  }
+];

--- a/src/routes/index.mdx
+++ b/src/routes/index.mdx
@@ -1,7 +1,3 @@
-import Counter from "~/components/Counter";
+import CurryDashboard from "~/components/CurryDashboard";
 
-# Hello World!
-
-<Counter />
-
-Visit [https://solidjs.com](https://solidjs.com) to learn how to build Solid apps.
+<CurryDashboard />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1218,6 +1218,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@kurkle/color@npm:^0.3.0":
+  version: 0.3.4
+  resolution: "@kurkle/color@npm:0.3.4"
+  checksum: 10c0/0e9fd55c614b005c5f0c4c755bca19ec0293bc7513b4ea3ec1725234f9c2fa81afbc78156baf555c8b9cb0d305619253c3f5bca016067daeebb3d00ebb4ea683
+  languageName: node
+  linkType: hard
+
 "@mapbox/node-pre-gyp@npm:^2.0.0":
   version: 2.0.0
   resolution: "@mapbox/node-pre-gyp@npm:2.0.0"
@@ -2736,6 +2743,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chart.js@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "chart.js@npm:4.5.0"
+  dependencies:
+    "@kurkle/color": "npm:^0.3.0"
+  checksum: 10c0/f12c7f9a238ee7ce6d3f7111628e9daba86bb8ff8e54cfe63525fde6ded9003c72c4c8d2c7d5702539dc0aff7e682dfec058660ade8d03a970da002656d4ac91
+  languageName: node
+  linkType: hard
+
 "chokidar@npm:^4.0.3":
   version: 4.0.3
   resolution: "chokidar@npm:4.0.3"
@@ -3677,7 +3693,9 @@ __metadata:
     "@solidjs/start": "npm:^1.1.0"
     "@types/node": "npm:^24.5.2"
     "@vinxi/plugin-mdx": "npm:^3.7.1"
+    chart.js: "npm:^4.5.0"
     nitropack: "npm:^2.12.6"
+    solid-chartjs: "npm:^1.3.11"
     solid-js: "npm:^1.9.5"
     solid-mdx: "npm:^0.0.7"
     vinxi: "npm:^0.5.7"
@@ -6663,6 +6681,16 @@ __metadata:
     ip-address: "npm:^10.0.1"
     smart-buffer: "npm:^4.2.0"
   checksum: 10c0/2805a43a1c4bcf9ebf6e018268d87b32b32b06fbbc1f9282573583acc155860dc361500f89c73bfbb157caa1b4ac78059eac0ef15d1811eb0ca75e0bdadbc9d2
+  languageName: node
+  linkType: hard
+
+"solid-chartjs@npm:^1.3.11":
+  version: 1.3.11
+  resolution: "solid-chartjs@npm:1.3.11"
+  peerDependencies:
+    chart.js: ^4.3.0
+    solid-js: ^1.7.5
+  checksum: 10c0/7b217e4dd443e0e77c827f0dcfcd25f40cb4036b5e59c11d7b6c9866541dc90272573e1c054b4aece98a75d45243976a1e013406108316485abe8b225332f5fe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- split the Curry dashboard into dedicated MDX components for the hero, stats grid, chart gallery, and game log table
- refactored the CurryDashboard shell to compose the new MDX sections and share the date-formatting helper

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68da24555688832e8d7e9b20a55f98fd