### PR TITLE
Add October 2 NBA schedule landing page

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -384,3 +384,200 @@ a:hover {
 .nba-games .error {
   color: #fecdd3;
 }
+
+.hero-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.october-dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.section-heading h2 {
+  margin: 0.35rem 0 0;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+}
+
+.section-heading .lead {
+  margin-top: 0.75rem;
+  max-width: 56ch;
+}
+
+.game-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.75rem;
+}
+
+.game-card {
+  background: var(--surface);
+  border-radius: 1.35rem;
+  border: 1px solid var(--border);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  box-shadow: 0 20px 48px rgba(2, 8, 23, 0.4);
+}
+
+.matchup {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 1rem;
+}
+
+.team {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.team .tricode {
+  font-size: 1.85rem;
+  font-weight: 700;
+}
+
+.team-name {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.at {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.game-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.85rem 1.25rem;
+}
+
+.game-meta dt {
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.game-meta dd {
+  margin: 0.25rem 0 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.game-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.broadcast-strip {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 1rem;
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  padding: 1rem 1.25rem;
+}
+
+.broadcast-strip p {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.7rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.broadcast-strip ul,
+.broadcast-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.broadcast-list li,
+.broadcast-strip li {
+  opacity: 0.85;
+}
+
+.empty-slate {
+  background: var(--surface);
+  border-radius: 1.5rem;
+  border: 1px solid var(--border);
+  padding: clamp(2rem, 4vw, 3.5rem);
+  text-align: center;
+  box-shadow: 0 20px 50px rgba(2, 8, 23, 0.35);
+}
+
+.empty-slate h2 {
+  margin-top: 0;
+  font-size: clamp(1.75rem, 3vw, 2.25rem);
+}
+
+.empty-slate p {
+  margin: 1rem auto 0;
+  color: var(--text-secondary);
+  max-width: 60ch;
+}
+
+.loading-panel {
+  padding: 1.25rem 1.5rem;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 1rem;
+  border: 1px solid var(--border);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-weight: 600;
+}
+
+.alert.error {
+  padding: 1.25rem 1.5rem;
+  border-radius: 1rem;
+  background: rgba(220, 38, 38, 0.15);
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  color: #fca5a5;
+  font-weight: 600;
+}
+
+.hero-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.meta-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.7rem;
+  color: rgba(148, 163, 184, 0.8);
+}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -15,6 +15,9 @@ export default function App() {
             </div>
             <nav class="main-nav">
               <A href="/" end activeClass="active">
+                October 2 Slate
+              </A>
+              <A href="/curry" activeClass="active">
                 Curry Showcase
               </A>
               <A href="/about" activeClass="active">

--- a/src/components/OctoberSecondGames.tsx
+++ b/src/components/OctoberSecondGames.tsx
@@ -1,0 +1,196 @@
+import { Show, createMemo, createResource } from "solid-js";
+import OctoberHero from "~/components/october/OctoberHero.mdx";
+import OctoberGamesList from "~/components/october/OctoberGamesList.mdx";
+import OctoberEmptyState from "~/components/october/OctoberEmptyState.mdx";
+
+const SCHEDULE_ENDPOINT = "https://cdn.nba.com/static/json/staticData/scheduleLeagueV2.json";
+const TARGET_DATE_KEY = "10/02/2025 00:00:00";
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "long",
+  day: "numeric",
+  year: "numeric",
+  weekday: "long",
+  timeZone: "America/New_York",
+});
+
+const timeFormatter = new Intl.DateTimeFormat("en-US", {
+  hour: "numeric",
+  minute: "2-digit",
+  timeZone: "America/New_York",
+  timeZoneName: "short",
+});
+
+type ScheduleResponse = {
+  leagueSchedule?: {
+    gameDates?: ScheduleDate[];
+  };
+};
+
+type ScheduleDate = {
+  gameDate?: string;
+  games?: ScheduleGame[];
+};
+
+type ScheduleGame = {
+  gameId: string;
+  gameStatusText: string;
+  gameLabel?: string;
+  gameSubLabel?: string;
+  gameDateTimeUTC: string;
+  arenaName?: string;
+  arenaCity?: string;
+  arenaState?: string;
+  isNeutral?: boolean;
+  broadcasters?: {
+    nationalBroadcasters?: Broadcaster[];
+    homeTvBroadcasters?: Broadcaster[];
+    awayTvBroadcasters?: Broadcaster[];
+  };
+  homeTeam: Team;
+  awayTeam: Team;
+};
+
+type Team = {
+  teamId: number;
+  teamName: string;
+  teamCity: string;
+  teamTricode: string;
+  teamSlug: string;
+};
+
+type Broadcaster = {
+  broadcasterDisplay?: string;
+};
+
+type OctoberGame = {
+  id: string;
+  label: string;
+  subLabel?: string;
+  statusText: string;
+  dateText: string;
+  tipoffText: string;
+  location: string;
+  neutralSite: boolean;
+  homeTeam: DisplayTeam;
+  awayTeam: DisplayTeam;
+  broadcasters: string[];
+};
+
+type DisplayTeam = {
+  name: string;
+  city: string;
+  tricode: string;
+};
+
+async function fetchOctoberSecondSchedule() {
+  const response = await fetch(SCHEDULE_ENDPOINT, {
+    headers: {
+      accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error("Unable to load the October 2 NBA slate.");
+  }
+
+  return (await response.json()) as ScheduleResponse;
+}
+
+function buildLocation(game: ScheduleGame) {
+  const parts = [game.arenaName, game.arenaCity, game.arenaState]
+    .filter(Boolean)
+    .map(segment => segment?.trim())
+    .filter(Boolean);
+
+  return parts.join(" · ") || "Venue TBA";
+}
+
+function collectBroadcasters(game: ScheduleGame) {
+  const pools = [
+    game.broadcasters?.nationalBroadcasters ?? [],
+    game.broadcasters?.homeTvBroadcasters ?? [],
+    game.broadcasters?.awayTvBroadcasters ?? [],
+  ];
+
+  const names = new Set<string>();
+
+  for (const pool of pools) {
+    for (const entry of pool) {
+      if (entry?.broadcasterDisplay) {
+        names.add(entry.broadcasterDisplay);
+      }
+    }
+  }
+
+  return [...names];
+}
+
+function normalizeGame(game: ScheduleGame): OctoberGame {
+  const date = new Date(game.gameDateTimeUTC);
+
+  return {
+    id: game.gameId,
+    label: game.gameLabel ?? "NBA Preseason",
+    subLabel: game.gameSubLabel,
+    statusText: game.gameStatusText,
+    dateText: dateFormatter.format(date),
+    tipoffText: timeFormatter.format(date),
+    location: buildLocation(game),
+    neutralSite: Boolean(game.isNeutral),
+    homeTeam: {
+      name: game.homeTeam.teamName,
+      city: game.homeTeam.teamCity,
+      tricode: game.homeTeam.teamTricode,
+    },
+    awayTeam: {
+      name: game.awayTeam.teamName,
+      city: game.awayTeam.teamCity,
+      tricode: game.awayTeam.teamTricode,
+    },
+    broadcasters: collectBroadcasters(game),
+  };
+}
+
+function findOctoberGames(data: ScheduleResponse) {
+  const gameDates = data.leagueSchedule?.gameDates ?? [];
+  const targetDate = gameDates.find(day => day.gameDate === TARGET_DATE_KEY);
+  const games = targetDate?.games ?? [];
+  return games.map(normalizeGame);
+}
+
+export default function OctoberSecondGames() {
+  const [schedule] = createResource(fetchOctoberSecondSchedule);
+
+  const games = createMemo(() => {
+    const data = schedule();
+    return data ? findOctoberGames(data) : [];
+  });
+
+  const headliner = createMemo(() => games()[0]);
+
+  return (
+    <section class="october-dashboard">
+      <Show when={schedule.error}>
+        {(error) => <p class="alert error">{error.message}</p>}
+      </Show>
+
+      <Show when={!schedule.error}>
+        <Show when={schedule.loading} fallback={null}>
+          <div class="loading-panel">Loading the October 2 slate…</div>
+        </Show>
+
+        <Show when={!schedule.loading}>
+          <Show when={games().length > 0} fallback={<OctoberEmptyState />}> 
+            {headliner() && (
+              <OctoberHero
+                game={headliner()!}
+              />
+            )}
+            <OctoberGamesList games={games()} />
+          </Show>
+        </Show>
+      </Show>
+    </section>
+  );
+}

--- a/src/components/october/OctoberEmptyState.mdx
+++ b/src/components/october/OctoberEmptyState.mdx
@@ -1,0 +1,11 @@
+export default function OctoberEmptyState() {
+  return (
+    <div class="empty-slate">
+      <h2>No NBA games on October 2</h2>
+      <p>
+        The league hasn&apos;t scheduled any matchups for this date yet. Check back closer to the fall for
+        updated preseason and regular-season announcements.
+      </p>
+    </div>
+  );
+}

--- a/src/components/october/OctoberGamesList.mdx
+++ b/src/components/october/OctoberGamesList.mdx
@@ -1,0 +1,68 @@
+export default function OctoberGamesList(props) {
+  const games = props.games ?? [];
+
+  return (
+    <section class="october-schedule">
+      <header class="section-heading">
+        <p class="eyebrow">Game slate</p>
+        <h2>Everything scheduled for October 2</h2>
+        <p class="lead">
+          From tip-off time to broadcast details, here&apos;s what to know before the ball goes up.
+        </p>
+      </header>
+      <div class="game-grid">
+        {games.map((game) => (
+          <article class="game-card">
+            <div class="matchup">
+              <div class="team away">
+                <span class="tricode">{game.awayTeam.tricode}</span>
+                <p class="team-name">
+                  {game.awayTeam.city} {game.awayTeam.name}
+                </p>
+              </div>
+              <span class="at">@</span>
+              <div class="team home">
+                <span class="tricode">{game.homeTeam.tricode}</span>
+                <p class="team-name">
+                  {game.homeTeam.city} {game.homeTeam.name}
+                </p>
+              </div>
+            </div>
+            <dl class="game-meta">
+              <div>
+                <dt>Tip-off</dt>
+                <dd>{game.tipoffText}</dd>
+              </div>
+              <div>
+                <dt>Date</dt>
+                <dd>{game.dateText}</dd>
+              </div>
+              <div>
+                <dt>Venue</dt>
+                <dd>{game.location}</dd>
+              </div>
+              <div>
+                <dt>Listing</dt>
+                <dd>{game.statusText}</dd>
+              </div>
+            </dl>
+            <div class="game-tags">
+              <span class="pill">{game.label}</span>
+              {game.subLabel && <span class="pill">{game.subLabel}</span>}
+            </div>
+            <div class="broadcast-strip">
+              <p>Watch on</p>
+              <ul>
+                {game.broadcasters.length > 0 ? (
+                  game.broadcasters.map((network) => <li>{network}</li>)
+                ) : (
+                  <li>Broadcast TBA</li>
+                )}
+              </ul>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/october/OctoberHero.mdx
+++ b/src/components/october/OctoberHero.mdx
@@ -1,0 +1,39 @@
+export default function OctoberHero(props) {
+  const game = props.game;
+
+  return (
+    <header class="dashboard-hero october-hero">
+      <div>
+        <p class="eyebrow">Global Games Spotlight</p>
+        <h1>
+          {game.awayTeam.city} {game.awayTeam.name} vs. {game.homeTeam.city} {game.homeTeam.name}
+        </h1>
+        <p class="lead">
+          Tip-off heads overseas as the preseason begins under the Etihad Arena lights. Track the
+          travel, the broadcast plan, and every detail about this neutral-site clash before the
+          action gets underway.
+        </p>
+        <div class="hero-pills">
+          <span class="pill">{game.label}</span>
+          {game.subLabel && <span class="pill">{game.subLabel}</span>}
+          {game.neutralSite && <span class="pill">Neutral site</span>}
+        </div>
+      </div>
+      <aside class="hero-highlight">
+        <h2>{game.tipoffText}</h2>
+        <p>{game.dateText}</p>
+        <p class="note">{game.location}</p>
+        <div class="hero-meta">
+          <p class="meta-label">Watch on</p>
+          <ul class="broadcast-list">
+            {game.broadcasters.length > 0 ? (
+              game.broadcasters.map((network) => <li>{network}</li>)
+            ) : (
+              <li>Broadcast details TBA</li>
+            )}
+          </ul>
+        </div>
+      </aside>
+    </header>
+  );
+}

--- a/src/routes/curry.mdx
+++ b/src/routes/curry.mdx
@@ -1,0 +1,11 @@
+import CurryDashboard from "~/components/CurryDashboard";
+import Counter from "~/components/Counter";
+import NbaGameLogs from "~/components/NbaGameLogs";
+
+<CurryDashboard />
+
+<Counter />
+
+<NbaGameLogs />
+
+> Data provided by ESPN's free [NBA scoreboard API](https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard).

--- a/src/routes/index.mdx
+++ b/src/routes/index.mdx
@@ -1,19 +1,3 @@
+import OctoberSecondGames from "~/components/OctoberSecondGames";
 
-import CurryDashboard from "~/components/CurryDashboard";
-import Counter from "~/components/Counter";
-import NbaGameLogs from "~/components/NbaGameLogs";
-
-
-
-<CurryDashboard />
-
-# Hello World!
-
-<Counter />
-
-Visit [https://solidjs.com](https://solidjs.com) to learn how to build Solid apps.
-
-<NbaGameLogs />
-
-> Data provided by ESPN's free [NBA scoreboard API](https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard).
-
+<OctoberSecondGames />


### PR DESCRIPTION
## Summary
- add a new October Second Games dashboard that fetches the NBA CDN schedule and surfaces the Oct 2 slate on the home page
- restructure routes so the Curry dashboard lives on /curry and navigation highlights the new home experience
- style the schedule view with MDX components for the hero, cards, and empty state messaging

## Testing
- yarn build *(fails: vite cannot resolve chart.js during SSR build)*

------
https://chatgpt.com/codex/tasks/task_e_68da385333f0832ea52254a486f48405