### PR TITLE
Fix October schedule fetch by proxying through API route

### DIFF
--- a/src/components/OctoberSecondGames.tsx
+++ b/src/components/OctoberSecondGames.tsx
@@ -3,7 +3,7 @@ import OctoberHero from "~/components/october/OctoberHero.mdx";
 import OctoberGamesList from "~/components/october/OctoberGamesList.mdx";
 import OctoberEmptyState from "~/components/october/OctoberEmptyState.mdx";
 
-const SCHEDULE_ENDPOINT = "https://cdn.nba.com/static/json/staticData/scheduleLeagueV2.json";
+const SCHEDULE_ENDPOINT = "/api/october-schedule";
 const TARGET_DATE_KEY = "10/02/2025 00:00:00";
 
 const dateFormatter = new Intl.DateTimeFormat("en-US", {

--- a/src/routes/api/october-schedule.ts
+++ b/src/routes/api/october-schedule.ts
@@ -1,0 +1,43 @@
+const NBA_SCHEDULE_ENDPOINT =
+  "https://cdn.nba.com/static/json/staticData/scheduleLeagueV2.json";
+
+const DEFAULT_HEADERS = {
+  "content-type": "application/json",
+  "cache-control": "public, max-age=600",
+};
+
+export async function GET() {
+  try {
+    const upstreamResponse = await fetch(NBA_SCHEDULE_ENDPOINT, {
+      headers: {
+        accept: "application/json",
+      },
+    });
+
+    if (!upstreamResponse.ok) {
+      return new Response(
+        JSON.stringify({ message: "Unable to load the October 2 NBA slate." }),
+        {
+          status: 502,
+          headers: DEFAULT_HEADERS,
+        },
+      );
+    }
+
+    const payload = await upstreamResponse.text();
+
+    return new Response(payload, {
+      status: 200,
+      headers: DEFAULT_HEADERS,
+    });
+  } catch (error) {
+    console.error("Failed to fetch October schedule", error);
+    return new Response(
+      JSON.stringify({ message: "Unable to load the October 2 NBA slate." }),
+      {
+        status: 500,
+        headers: DEFAULT_HEADERS,
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- update the October 2 games component to load data from an internal API endpoint instead of the NBA CDN directly
- add a Cloudflare Worker API route that proxies the NBA schedule feed with JSON/caching headers and upstream error handling to avoid client-side CORS failures

## Testing
- yarn build *(fails: Rollup cannot resolve optional chart.js dependency in CurryDashboard.tsx; existing issue unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68da42817e48832e92e7cf1a094f6008