### PR TITLE
Add dynamic schedule date picker to October slate page

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -412,6 +412,73 @@ a:hover {
   gap: 2.5rem;
 }
 
+.schedule-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: flex-end;
+  justify-content: space-between;
+  background: var(--surface);
+  border-radius: 1.35rem;
+  border: 1px solid var(--border);
+  padding: clamp(1.25rem, 2.5vw, 2rem) clamp(1.5rem, 3vw, 2.5rem);
+  box-shadow: 0 24px 48px rgba(2, 8, 23, 0.45);
+}
+
+.toolbar-copy {
+  flex: 1 1 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.toolbar-copy h2 {
+  margin: 0;
+  font-size: clamp(1.9rem, 3vw, 2.6rem);
+}
+
+.toolbar-copy .lead {
+  margin: 0;
+  max-width: 60ch;
+}
+
+.date-picker {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.date-picker span {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.7rem;
+}
+
+.date-picker input[type="date"] {
+  appearance: none;
+  border: 1px solid var(--border);
+  border-radius: 0.85rem;
+  background: rgba(15, 23, 42, 0.55);
+  color: var(--text-primary);
+  padding: 0.65rem 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.35);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.date-picker input[type="date"]:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.35);
+}
+
+.date-picker input[type="date"]::-webkit-calendar-picker-indicator {
+  filter: invert(1);
+}
+
 .section-heading h2 {
   margin: 0.35rem 0 0;
   font-size: clamp(1.8rem, 3vw, 2.4rem);

--- a/src/components/october/OctoberEmptyState.mdx
+++ b/src/components/october/OctoberEmptyState.mdx
@@ -1,7 +1,8 @@
-export default function OctoberEmptyState() {
+export default function OctoberEmptyState(props) {
+  const dateText = props?.dateText ?? "this date";
   return (
     <div class="empty-slate">
-      <h2>No NBA games on October 2</h2>
+      <h2>No NBA games on {dateText}</h2>
       <p>
         The league hasn&apos;t scheduled any matchups for this date yet. Check back closer to the fall for
         updated preseason and regular-season announcements.

--- a/src/components/october/OctoberGamesList.mdx
+++ b/src/components/october/OctoberGamesList.mdx
@@ -1,11 +1,12 @@
 export default function OctoberGamesList(props) {
   const games = props.games ?? [];
+  const dateText = props.dateText ?? "this date";
 
   return (
     <section class="october-schedule">
       <header class="section-heading">
         <p class="eyebrow">Game slate</p>
-        <h2>Everything scheduled for October 2</h2>
+        <h2>Everything scheduled for {dateText}</h2>
         <p class="lead">
           From tip-off time to broadcast details, here&apos;s what to know before the ball goes up.
         </p>


### PR DESCRIPTION
## Summary
- add a schedule toolbar with a date picker so visitors can choose preseason dates after October 2
- derive the selected date key to filter the NBA schedule data and update hero/list content dynamically
- refresh empty state and list headings to reference the chosen date and polish styling for the picker

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68ddf2fe4a3c832e96fba8e69a6ce1f7