### PR TITLE
Add date picker to NBA schedule view

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -412,6 +412,76 @@ a:hover {
   gap: 2.5rem;
 }
 
+.schedule-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  background: var(--surface-strong);
+  border-radius: 1.5rem;
+  border: 1px solid var(--border);
+  padding: clamp(1.75rem, 3vw, 2.5rem);
+  box-shadow: 0 24px 60px rgba(2, 8, 23, 0.45);
+}
+
+.schedule-controls .section-heading {
+  margin: 0;
+}
+
+.schedule-controls .section-heading .lead {
+  margin-bottom: 0;
+}
+
+.date-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.date-selector span {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.75rem;
+}
+
+.date-selector input {
+  appearance: none;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 0.65rem 0.95rem;
+  color: var(--text-primary);
+  font: inherit;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.date-selector input::-webkit-calendar-picker-indicator {
+  filter: invert(0.85);
+  opacity: 0.85;
+  cursor: pointer;
+}
+
+.date-selector input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(249, 115, 22, 0.35);
+}
+
+@media (min-width: 720px) {
+  .schedule-controls {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .schedule-controls .section-heading {
+    max-width: 48ch;
+  }
+}
+
 .section-heading h2 {
   margin: 0.35rem 0 0;
   font-size: clamp(1.8rem, 3vw, 2.4rem);

--- a/src/components/OctoberSecondGames.tsx
+++ b/src/components/OctoberSecondGames.tsx
@@ -1,10 +1,10 @@
-import { Show, createMemo, createResource } from "solid-js";
+import { Show, createMemo, createResource, createSignal } from "solid-js";
 import OctoberHero from "~/components/october/OctoberHero.mdx";
 import OctoberGamesList from "~/components/october/OctoberGamesList.mdx";
 import OctoberEmptyState from "~/components/october/OctoberEmptyState.mdx";
 
 const SCHEDULE_ENDPOINT = "https://cdn.nba.com/static/json/staticData/scheduleLeagueV2.json";
-const TARGET_DATE_KEY = "10/02/2025 00:00:00";
+const DEFAULT_DATE = "2025-10-02";
 
 const dateFormatter = new Intl.DateTimeFormat("en-US", {
   month: "long",
@@ -152,9 +152,33 @@ function normalizeGame(game: ScheduleGame): OctoberGame {
   };
 }
 
-function findOctoberGames(data: ScheduleResponse) {
+function buildDateKey(dateISO: string) {
+  const [year, month, day] = dateISO.split("-");
+
+  if (!year || !month || !day) {
+    return "";
+  }
+
+  return `${month}/${day}/${year} 00:00:00`;
+}
+
+function formatDateLabel(dateISO: string) {
+  const [yearString, monthString, dayString] = dateISO.split("-");
+  const year = Number(yearString);
+  const month = Number(monthString);
+  const day = Number(dayString);
+
+  if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day)) {
+    return "the selected date";
+  }
+
+  const reference = new Date(Date.UTC(year, month - 1, day, 12));
+  return dateFormatter.format(reference);
+}
+
+function findOctoberGames(data: ScheduleResponse, dateKey: string) {
   const gameDates = data.leagueSchedule?.gameDates ?? [];
-  const targetDate = gameDates.find(day => day.gameDate === TARGET_DATE_KEY);
+  const targetDate = gameDates.find(day => day.gameDate === dateKey);
   const games = targetDate?.games ?? [];
   return games.map(normalizeGame);
 }
@@ -162,32 +186,64 @@ function findOctoberGames(data: ScheduleResponse) {
 export default function OctoberSecondGames() {
   const [schedule] = createResource(fetchOctoberSecondSchedule);
 
+  const [selectedDate, setSelectedDate] = createSignal(DEFAULT_DATE);
+
+  const selectedDateKey = createMemo(() => buildDateKey(selectedDate()));
+
   const games = createMemo(() => {
     const data = schedule();
-    return data ? findOctoberGames(data) : [];
+    const dateKey = selectedDateKey();
+    return data && dateKey ? findOctoberGames(data, dateKey) : [];
   });
 
   const headliner = createMemo(() => games()[0]);
+  const selectedDateLabel = createMemo(() => formatDateLabel(selectedDate()));
+
+  const handleDateInput = (event: InputEvent & { currentTarget: HTMLInputElement; target: HTMLInputElement }) => {
+    const value = event.currentTarget.value;
+    setSelectedDate(value || DEFAULT_DATE);
+  };
 
   return (
     <section class="october-dashboard">
+      <header class="schedule-controls">
+        <div class="section-heading">
+          <p class="eyebrow">NBA schedule</p>
+          <h2>Games for {selectedDateLabel()}</h2>
+          <p class="lead">
+            Pick a date to explore upcoming preseason and regular-season matchups as they&apos;re announced.
+          </p>
+        </div>
+        <label class="date-selector">
+          <span>Choose a date</span>
+          <input
+            type="date"
+            value={selectedDate()}
+            onInput={handleDateInput}
+          />
+        </label>
+      </header>
+
       <Show when={schedule.error}>
         {(error) => <p class="alert error">{error.message}</p>}
       </Show>
 
       <Show when={!schedule.error}>
         <Show when={schedule.loading} fallback={null}>
-          <div class="loading-panel">Loading the October 2 slate…</div>
+          <div class="loading-panel">Loading the latest NBA schedule…</div>
         </Show>
 
         <Show when={!schedule.loading}>
-          <Show when={games().length > 0} fallback={<OctoberEmptyState />}> 
+          <Show
+            when={games().length > 0}
+            fallback={<OctoberEmptyState dateLabel={selectedDateLabel()} />}
+          >
             {headliner() && (
               <OctoberHero
                 game={headliner()!}
               />
             )}
-            <OctoberGamesList games={games()} />
+            <OctoberGamesList games={games()} dateLabel={selectedDateLabel()} />
           </Show>
         </Show>
       </Show>

--- a/src/components/october/OctoberEmptyState.mdx
+++ b/src/components/october/OctoberEmptyState.mdx
@@ -1,9 +1,11 @@
-export default function OctoberEmptyState() {
+export default function OctoberEmptyState(props) {
+  const dateLabel = props.dateLabel ?? "this date";
+
   return (
     <div class="empty-slate">
-      <h2>No NBA games on October 2</h2>
+      <h2>No NBA games on {dateLabel}</h2>
       <p>
-        The league hasn&apos;t scheduled any matchups for this date yet. Check back closer to the fall for
+        The league hasn&apos;t scheduled any matchups for this day yet. Check back closer to the fall for
         updated preseason and regular-season announcements.
       </p>
     </div>

--- a/src/components/october/OctoberGamesList.mdx
+++ b/src/components/october/OctoberGamesList.mdx
@@ -1,11 +1,12 @@
 export default function OctoberGamesList(props) {
   const games = props.games ?? [];
+  const dateLabel = props.dateLabel ?? "the selected date";
 
   return (
     <section class="october-schedule">
       <header class="section-heading">
         <p class="eyebrow">Game slate</p>
-        <h2>Everything scheduled for October 2</h2>
+        <h2>Everything scheduled for {dateLabel}</h2>
         <p class="lead">
           From tip-off time to broadcast details, here&apos;s what to know before the ball goes up.
         </p>


### PR DESCRIPTION
## Summary
- add a schedule control header with a date picker and dynamic filtering
- update the schedule list and empty state copy to reflect the chosen date
- style the new schedule controls and date picker to match the dashboard

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68df5ec37530832ebcf249bd4dc5e8ac